### PR TITLE
Fix/standard inspection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-source",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Event broker for BeSpiral smart contracts",
   "main": "src/app.js",
   "scripts": {


### PR DESCRIPTION
Right now `standard` format the whole project folder, this PR change `standard` behavior to format only `./src/` folder.

This needs to be done because some folders (that are not part of the project itself) are at the same structure level of the project and demands permission to be accessed, so `standard` fails during the format action.

![image](https://user-images.githubusercontent.com/26880912/62577673-d2460780-b875-11e9-9983-25ad6b031d73.png)
