### PR TITLE
fix: align event-source handlers with contract actions

### DIFF
--- a/src/GetActionsHandler.js
+++ b/src/GetActionsHandler.js
@@ -1,0 +1,62 @@
+const { MassiveActionHandler } = require('demux-postgres')
+
+// Extends MassiveActionHandler to work with GetActionsReader:
+// - Skips sequential block number and hash checks (get_actions guarantees ordering)
+// - Skips DB writes for empty gap-filling blocks (only writes for action blocks)
+class GetActionsHandler extends MassiveActionHandler {
+  async handleBlock (block, isRollback, isFirstBlock, isReplay = false) {
+    const { blockInfo } = block
+
+    // Load persisted state on first ever call
+    if (!this.lastProcessedBlockHash && this.lastProcessedBlockNumber === 0) {
+      await this.refreshIndexState()
+    }
+
+    // Skip if we've already processed this exact block
+    if (
+      blockInfo.blockNumber === this.lastProcessedBlockNumber &&
+      blockInfo.blockHash === this.lastProcessedBlockHash
+    ) {
+      return [false, 0]
+    }
+
+    // On fresh start with existing state, tell watcher to seek to resume position
+    if (isFirstBlock && this.lastProcessedBlockHash) {
+      return [true, this.lastProcessedBlockNumber + 1]
+    }
+
+    // Empty block — update in-memory state only, no DB transaction
+    if (!block.actions || block.actions.length === 0) {
+      this.lastProcessedBlockNumber = blockInfo.blockNumber
+      this.lastProcessedBlockHash = blockInfo.blockHash
+      return [false, 0]
+    }
+
+    // Action block — run full pipeline inside a DB transaction
+    await this.handleWithState(async (state, context = {}) => {
+      await this.handleActions(state, block, context, isReplay)
+    })
+
+    return [false, 0]
+  }
+
+  // Override to use ON CONFLICT DO NOTHING for _block_number_txid.
+  // Re-processed blocks (e.g. after switching from NodeosActionReader) would otherwise
+  // crash with a duplicate key violation since that table has no upsert support.
+  async updateIndexState (state, block, isReplay, context) {
+    const { blockInfo } = block
+    const fromDb = (await state._index_state.findOne({ id: 1 })) || {}
+    const toSave = Object.assign({}, fromDb, {
+      block_number: blockInfo.blockNumber,
+      block_hash: blockInfo.blockHash,
+      is_replay: isReplay
+    })
+    await state._index_state.save(toSave)
+    await state.instance.none(
+      'INSERT INTO _block_number_txid (block_number, txid) VALUES ($1, $2) ON CONFLICT DO NOTHING',
+      [blockInfo.blockNumber, context.txid]
+    )
+  }
+}
+
+module.exports = { GetActionsHandler }

--- a/src/GetActionsReader.js
+++ b/src/GetActionsReader.js
@@ -1,0 +1,243 @@
+const http = require('http')
+const https = require('https')
+const { URL } = require('url')
+const { AbstractActionReader } = require('demux')
+
+const HEAD_REFRESH_MS = 2000
+
+class GetActionsReader extends AbstractActionReader {
+  constructor (nodeUrl, contracts, startAtBlock) {
+    super(startAtBlock)
+    this.nodeUrl = nodeUrl
+    this.contracts = contracts
+    this.seqPositions = {}
+    this.initialized = false
+    this.pendingActions = []
+    this.seenGlobalSeqs = new Set()
+    this._headRefreshedAt = 0
+    this._everReturnedBlock = false
+  }
+
+  _post (path, body) {
+    return new Promise((resolve, reject) => {
+      const url = new URL(path, this.nodeUrl)
+      const data = JSON.stringify(body)
+      const transport = url.protocol === 'https:' ? https : http
+      const options = {
+        hostname: url.hostname,
+        port: url.port || (url.protocol === 'https:' ? 443 : 80),
+        path: url.pathname,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(data)
+        }
+      }
+      const req = transport.request(options, res => {
+        const chunks = []
+        res.on('data', chunk => chunks.push(chunk))
+        res.on('end', () => {
+          try { resolve(JSON.parse(Buffer.concat(chunks).toString())) } catch (e) { reject(e) }
+        })
+      })
+      req.on('error', reject)
+      req.write(data)
+      req.end()
+    })
+  }
+
+  async getHeadBlockNumber () {
+    const now = Date.now()
+    if (now - this._headRefreshedAt > HEAD_REFRESH_MS) {
+      const info = await this._post('/v1/chain/get_info', {})
+      this.headBlockNumber = info.head_block_num
+      this._headRefreshedAt = now
+    }
+    return this.headBlockNumber
+  }
+
+  // Fallback for base-class seekToBlock internals (private chain — no real forks)
+  async getBlock (blockNumber) {
+    return this._syntheticBlock(blockNumber)
+  }
+
+  _syntheticBlock (blockNumber) {
+    return {
+      blockInfo: {
+        blockNumber,
+        blockHash: `synthetic-${blockNumber}`,
+        previousBlockHash: `synthetic-${blockNumber - 1}`,
+        timestamp: new Date()
+      },
+      actions: []
+    }
+  }
+
+  async _fetchActions (contract, pos, offset) {
+    return this._post('/v1/history/get_actions', { account_name: contract, pos, offset })
+  }
+
+  // Binary search: first account_action_seq where block_num >= fromBlock
+  async _findSeqForBlock (contract, fromBlock) {
+    const lastResult = await this._fetchActions(contract, -1, -1)
+    if (!lastResult.actions || lastResult.actions.length === 0) return 0
+
+    const last = lastResult.actions[0]
+    if (last.block_num < fromBlock) {
+      return last.account_action_seq + 1 // start past the end
+    }
+
+    const total = last.account_action_seq + 1
+    let lo = 0
+    let hi = total - 1
+
+    while (lo < hi) {
+      const mid = Math.floor((lo + hi) / 2)
+      const result = await this._fetchActions(contract, mid, 1)
+      if (!result.actions || result.actions.length === 0) { hi = mid; continue }
+      if (result.actions[0].block_num < fromBlock) {
+        lo = mid + 1
+      } else {
+        hi = mid
+      }
+    }
+    return lo
+  }
+
+  async _initSeqPositions (fromBlock) {
+    for (const contract of this.contracts) {
+      this.seqPositions[contract] = await this._findSeqForBlock(contract, fromBlock)
+      console.info(`GetActionsReader: ${contract} seq starts at ${this.seqPositions[contract]} (from block ${fromBlock})`)
+    }
+  }
+
+  async initialize () {
+    if (this.initialized) return
+    console.info('GetActionsReader: locating start sequences...')
+    await this._initSeqPositions(this.startAtBlock)
+    this.initialized = true
+    console.info('GetActionsReader: ready')
+  }
+
+  async _loadNextBatch () {
+    const BATCH_SIZE = 100
+    let anyNew = false
+
+    for (const contract of this.contracts) {
+      const result = await this._fetchActions(contract, this.seqPositions[contract], BATCH_SIZE)
+      if (!result.actions || result.actions.length === 0) continue
+
+      for (const action of result.actions) {
+        const act = action.action_trace.act
+        if (act.account !== contract) continue
+        if (this.seenGlobalSeqs.has(action.global_action_seq)) continue
+
+        this.seenGlobalSeqs.add(action.global_action_seq)
+        this.pendingActions.push({
+          blockNum: action.block_num,
+          blockTime: new Date(action.block_time + 'Z'),
+          type: `${act.account}::${act.name}`,
+          payload: {
+            ...act,
+            transactionId: action.action_trace.trx_id,
+            actionIndex: action.account_action_seq
+          }
+        })
+
+        anyNew = true
+        this.seqPositions[contract] = action.account_action_seq + 1
+      }
+    }
+
+    if (anyNew) {
+      this.pendingActions.sort((a, b) => a.blockNum - b.blockNum)
+    }
+
+    return anyNew
+  }
+
+  async seekToBlock (blockNumber) {
+    // Called by watcher as seekToBlock(nextBlockNeeded - 1), so resume from blockNumber+1
+    const resumeFrom = blockNumber + 1
+    console.info(`GetActionsReader: seeking to block ${blockNumber}, will resume from ${resumeFrom}`)
+    await this._initSeqPositions(resumeFrom)
+    this.pendingActions = []
+    this.seenGlobalSeqs = new Set()
+    this.currentBlockNumber = blockNumber
+    this.currentBlockData = this._syntheticBlock(blockNumber)
+    this.headBlockNumber = 0
+    this._headRefreshedAt = 0
+  }
+
+  async nextBlock () {
+    if (!this.initialized) await this.initialize()
+
+    await this.getHeadBlockNumber()
+
+    const targetBlock = this.currentBlockNumber + 1
+
+    // If we have a pending action exactly at targetBlock, return it
+    if (this.pendingActions.length > 0 && this.pendingActions[0].blockNum === targetBlock) {
+      return this._returnActionBlock(targetBlock)
+    }
+
+    // If pending action is AHEAD of targetBlock, fill gap with synthetic block
+    if (this.pendingActions.length > 0 && this.pendingActions[0].blockNum > targetBlock) {
+      return this._returnSyntheticBlock(targetBlock)
+    }
+
+    // Buffer empty — try to load more
+    if (this.pendingActions.length === 0) {
+      await this._loadNextBatch()
+    }
+
+    if (this.pendingActions.length > 0) {
+      if (this.pendingActions[0].blockNum === targetBlock) {
+        return this._returnActionBlock(targetBlock)
+      }
+      // Next action is ahead — fill gap
+      return this._returnSyntheticBlock(targetBlock)
+    }
+
+    // No more actions — jump to head so watcher exits the polling loop
+    this.currentBlockNumber = this.headBlockNumber
+    this.currentBlockData = this._syntheticBlock(this.headBlockNumber)
+    this.isFirstBlock = false
+    return [this.currentBlockData, false, false] // isNewBlock=false → watcher breaks
+  }
+
+  _returnSyntheticBlock (blockNumber) {
+    const blockData = this._syntheticBlock(blockNumber)
+    this.currentBlockData = blockData
+    this.currentBlockNumber = blockNumber
+    this.isFirstBlock = !this._everReturnedBlock
+    this._everReturnedBlock = true
+    return [blockData, false, true]
+  }
+
+  _returnActionBlock (blockNumber) {
+    const blockTime = this.pendingActions[0].blockTime
+    const actions = []
+    while (this.pendingActions.length > 0 && this.pendingActions[0].blockNum === blockNumber) {
+      const { type, payload } = this.pendingActions.shift()
+      actions.push({ type, payload })
+    }
+    console.info(`GetActionsReader: block ${blockNumber} — ${actions.map(a => a.type).join(', ')}`)
+    const blockData = {
+      blockInfo: {
+        blockNumber,
+        blockHash: `synthetic-${blockNumber}`,
+        previousBlockHash: `synthetic-${blockNumber - 1}`,
+        timestamp: blockTime
+      },
+      actions
+    }
+    this.currentBlockData = blockData
+    this.currentBlockNumber = blockNumber
+    this.isFirstBlock = !this._everReturnedBlock
+    this._everReturnedBlock = true
+    return [blockData, false, true]
+  }
+}
+
+module.exports = { GetActionsReader }

--- a/src/GetActionsReader.js
+++ b/src/GetActionsReader.js
@@ -49,9 +49,14 @@ class GetActionsReader extends AbstractActionReader {
   async getHeadBlockNumber () {
     const now = Date.now()
     if (now - this._headRefreshedAt > HEAD_REFRESH_MS) {
-      const info = await this._post('/v1/chain/get_info', {})
-      this.headBlockNumber = info.head_block_num
-      this._headRefreshedAt = now
+      try {
+        const info = await this._post('/v1/chain/get_info', {})
+        this.headBlockNumber = info.head_block_num
+        this._headRefreshedAt = now
+      } catch (e) {
+        console.error('GetActionsReader: failed to fetch head block number:', e.message)
+        // return cached value; will retry next time cache expires
+      }
     }
     return this.headBlockNumber
   }
@@ -186,9 +191,14 @@ class GetActionsReader extends AbstractActionReader {
       return this._returnSyntheticBlock(targetBlock)
     }
 
-    // Buffer empty — try to load more
+    // Buffer empty — try to load more (catch transient network errors so we don't crash)
     if (this.pendingActions.length === 0) {
-      await this._loadNextBatch()
+      try {
+        await this._loadNextBatch()
+      } catch (e) {
+        console.error('GetActionsReader: network error fetching actions, will retry next poll:', e.message)
+        return [this.currentBlockData || this._syntheticBlock(this.currentBlockNumber), false, false]
+      }
     }
 
     if (this.pendingActions.length > 0) {

--- a/src/app.js
+++ b/src/app.js
@@ -1,8 +1,8 @@
 const config = require(`./config/${process.env.NODE_ENV || 'dev'}`)
 const massive = require('massive')
 const { BaseActionWatcher } = require('demux')
-const { NodeosActionReader } = require('demux-eos')
-const { MassiveActionHandler } = require('demux-postgres')
+const { GetActionsReader } = require('./GetActionsReader')
+const { GetActionsHandler } = require('./GetActionsHandler')
 const { logInit, logExit } = require('./logging')
 
 const updaters = require('./updaters')
@@ -11,17 +11,19 @@ const effects = []
 const http = require('http')
 
 async function init () {
-  const actionReader = new NodeosActionReader(
+  const contracts = [config.blockchain.contract.community, config.blockchain.contract.token]
+  const actionReader = new GetActionsReader(
     config.blockchain.url,
+    contracts,
     config.blockchain.initialBlock
   )
   console.info(
-    `Querying EOS node on ${config.blockchain.url} on block#${config.blockchain.initialBlock}`
+    `Querying EOS node on ${config.blockchain.url} via get_actions for ${contracts.join(', ')} from block#${config.blockchain.initialBlock}`
   )
 
   massive(config.db).then(db => {
     console.info('Connected to postgres')
-    const actionHandler = new MassiveActionHandler(
+    const actionHandler = new GetActionsHandler(
       updaters,
       effects,
       db,

--- a/src/updaters.js
+++ b/src/updaters.js
@@ -3,10 +3,6 @@ const {
   createCommunity,
   updateCommunity,
   netlink,
-  createSale,
-  updateSale,
-  deleteSale,
-  reactSale,
   transferSale,
   upsertObjective,
   upsertAction,
@@ -22,7 +18,8 @@ const {
   transfer,
   issue,
   retire,
-  setExpiry
+  setExpiry,
+  initacc
 } = require('./updaters/token.js')
 
 const updaters = [
@@ -50,22 +47,6 @@ const updaters = [
   {
     actionType: `${config.blockchain.contract.community}::reward`,
     updater: reward
-  },
-  {
-    actionType: `${config.blockchain.contract.community}::createsale`,
-    updater: createSale
-  },
-  {
-    actionType: `${config.blockchain.contract.community}::updatesale`,
-    updater: updateSale
-  },
-  {
-    actionType: `${config.blockchain.contract.community}::deletesale`,
-    updater: deleteSale
-  },
-  {
-    actionType: `${config.blockchain.contract.community}::reactsale`,
-    updater: reactSale
   },
   {
     actionType: `${config.blockchain.contract.community}::transfersale`,
@@ -111,6 +92,10 @@ const updaters = [
   {
     actionType: `${config.blockchain.contract.token}::setexpiry`,
     updater: setExpiry
+  },
+  {
+    actionType: `${config.blockchain.contract.token}::initacc`,
+    updater: initacc
   }
 ]
 

--- a/src/updaters/community.js
+++ b/src/updaters/community.js
@@ -126,7 +126,7 @@ async function updateCommunity(db, payload, blockInfo, context) {
       symbol: symbol,
       logo: payload.data.logo === "" ? null : payload.data.logo,
       name: payload.data.name,
-      description: payload.data.description === "" ? null : payload.data.description,
+      description: payload.data.description === "" ? "Cambiatus Community" : payload.data.description,
       inviter_reward: parseToken(payload.data.inviter_reward)[0],
       invited_reward: parseToken(payload.data.invited_reward)[0],
       has_objectives: payload.data.has_objectives === 1,

--- a/src/updaters/community.js
+++ b/src/updaters/community.js
@@ -210,160 +210,6 @@ async function netlink(db, payload, blockInfo, context) {
   }
 }
 
-function createSale(db, payload, blockInfo, context) {
-  console.log(`Cambiatus >>> New Sale`, blockInfo.blockNumber)
-
-  const [price] = parseToken(payload.data.quantity)
-  const symbol = getSymbolFromAsset(payload.data.quantity)
-  const trackStock = payload.data.track_stock === 1
-  const units = trackStock ? payload.data.units : 0
-
-  const data = {
-    community_id: symbol,
-    title: payload.data.title,
-    description: payload.data.description === "" ? null : payload.data.description,
-    price: price,
-    image: payload.data.image == "" ? null : payload.data.image,
-    units: units,
-    track_stock: trackStock,
-    is_deleted: false,
-    creator_id: payload.data.from,
-    created_block: blockInfo.blockNumber,
-    created_tx: payload.transactionId,
-    created_eos_account: payload.authorization[0].actor,
-    created_at: blockInfo.timestamp
-  }
-
-  // Insert sale on database
-  db.products
-    .insert(data)
-    .catch(e => logError('Something went wrong while creating a new sale', e))
-}
-
-function updateSale(db, payload, blockInfo, context) {
-  console.log(`Cambiatus >>> Update sale`, blockInfo.blockNumber)
-
-  const whereArg = {
-    id: payload.data.sale_id,
-    is_deleted: false
-  }
-
-  db.products
-    .findOne(whereArg)
-    .then(sale => {
-      if (sale == null) {
-        throw new Error('No sale data available')
-      }
-
-      const [price] = parseToken(payload.data.quantity)
-      const units = payload.data.track_stock === 1 ? payload.data.units : 0
-      const trackStock = payload.data.track_stock === 1
-
-      // Update sale data
-      const updateData = {
-        title: payload.data.title,
-        description: payload.data.description === "" ? null : payload.data.description,
-        price: price,
-        image: payload.data.image == "" ? null : payload.data.image,
-        track_stock: trackStock,
-        units: units
-      }
-
-      db.products
-        .update(whereArg, updateData)
-        .catch(e =>
-          logError(
-            'Something went wrong while updating sale, make sure that sale is not deleted',
-            e
-          )
-        )
-    })
-    .catch(e =>
-      logError(
-        'Something went wrong while looking for the sale, make sure that sale is not deleted',
-        e
-      )
-    )
-}
-
-function deleteSale(db, payload, blockInfo, context) {
-  console.log(`Cambiatus >>> Remove sale`, blockInfo.blockNumber)
-
-  // Soft delete sale
-  const updateData = {
-    is_deleted: true,
-    deleted_at: blockInfo.timestamp
-  }
-
-  db.products
-    .update(
-      {
-        id: payload.data.sale_id,
-        is_deleted: false
-      },
-      updateData
-    )
-    .catch(e =>
-      logError(
-        'Something went wrong while removing sale, make sure that sale is not deleted',
-        e
-      )
-    )
-}
-
-function reactSale(db, payload, blockInfo, context) {
-  console.log(`Cambiatus >>> Vote in a sale`, blockInfo.blockNumber)
-
-  const transaction = tx => {
-    // Find sale
-    tx.products
-      .findOne({
-        id: payload.data.sale_id,
-        is_deleted: false
-      })
-      .then(sale => {
-        if (sale === null) {
-          throw new Error('No sale data available')
-        }
-
-        const whereArg = {
-          product_id: sale.id,
-          account_id: payload.data.from
-        }
-
-        // Check if sale was previously voted
-        tx.sale_ratings.count(whereArg).then(total => {
-          if (total === '0') {
-            const data = {
-              product_id: sale.id,
-              account_id: payload.data.from,
-              rating: payload.data.type,
-              created_block: blockInfo.blockNumber,
-              created_tx: payload.transactionId,
-              created_eos_account: payload.authorization[0].actor,
-              created_at: blockInfo.timestamp
-            }
-
-            tx.sale_ratings.insert(data)
-          } else {
-            const updateData = {
-              rating: payload.data.type
-            }
-
-            tx.sale_ratings.update(whereArg, updateData)
-          }
-        })
-      })
-  }
-
-  db.withTransaction(transaction).catch(e =>
-    logError(
-      'Something went wrong while reacting to a sale, make sure that sale is not deleted',
-      e
-    )
-  )
-}
-
 function transferSale(db, payload, blockInfo, context) {
   console.log(`Cambiatus >>> New Transfer Sale`, blockInfo.blockNumber)
 
@@ -686,7 +532,7 @@ async function upsertRole(db, payload, blockInfo, _context) {
   }
 
   try {
-    const existingRole = await db.roles.findOne({ name: payload.data.name })
+    const existingRole = await db.roles.findOne({ name: payload.data.name, community_id: payload.data.community_id })
     if (existingRole != null) {
       roleData = Object.assign(roleData, { id: existingRole.id })
     }
@@ -744,10 +590,6 @@ module.exports = {
   upsertObjective,
   upsertAction,
   reward,
-  createSale,
-  updateSale,
-  deleteSale,
-  reactSale,
   transferSale,
   verifyClaim,
   claimAction,

--- a/src/updaters/token.js
+++ b/src/updaters/token.js
@@ -84,9 +84,36 @@ function issue (db, payload, blockInfo, context) {
     )
 }
 
-function retire (db, payload, blockInfo, context) {}
+function retire(db, payload, blockInfo, context) {
+  console.log(`Cambiatus >>> Retire tokens for ${payload.data.currency} (${payload.data.user_type})`)
+}
 
-function setExpiry (db, payload, blockInfo, context) {}
+async function setExpiry(db, payload, blockInfo, context) {
+  console.log(`Cambiatus >>> Set Expiry`, blockInfo.blockNumber)
+
+  const currency = payload.data.currency
+  const updateData = {
+    expiration_period: payload.data.natural_expiration_period,
+    renovation_amount: parseToken(payload.data.renovation_amount)[0]
+  }
+
+  const existing = await db.expiry_options.findOne({ community_id: currency })
+    .catch(e => { logError('Error looking up expiry_options', e) })
+
+  if (existing) {
+    db.expiry_options
+      .update({ community_id: currency }, updateData)
+      .catch(e => logError('Something went wrong while updating expiry options', e))
+  } else {
+    db.expiry_options
+      .insert({ community_id: currency, ...updateData })
+      .catch(e => logError('Something went wrong while inserting expiry options', e))
+  }
+}
+
+function initacc(db, payload, blockInfo, context) {
+  console.log(`Cambiatus >>> Init Account ${payload.data.account} for ${payload.data.currency}`)
+}
 
 module.exports = {
   createToken,
@@ -94,5 +121,6 @@ module.exports = {
   transfer,
   issue,
   retire,
-  setExpiry
+  setExpiry,
+  initacc
 }


### PR DESCRIPTION
## Summary

- **perf**: replace block-scan with `get_actions` reader for sparse chains — avoids scanning thousands of empty blocks
- **fix**: catch transient network errors in `GetActionsReader` instead of crashing
- **fix**: align all event-source handlers with the current contract EOSIO_DISPATCH:
  - Remove 4 dead sale handlers (`createsale/updatesale/deletesale/reactsale`) not in contract dispatch
  - Fix `upsertRole` cross-community bug: `findOne` now filters by `community_id`
  - Implement `setExpiry` to upsert `expiry_options` table
  - Add `initacc` handler registration
  - `retire` now logs the event
- **fix**: absorb live server hotfix — empty `description` on `updateCommunity` falls back to `"Cambiatus Community"` instead of null

## Test plan

- [ ] `yarn format` passes (StandardJS)
- [ ] `pm2 restart event-source` on `app.cambiatus.io`, confirm no crash on startup
- [ ] `pm2 logs event-source` — verify block processing resumes from last checkpoint
- [ ] Trigger a `upsertrole` action on devnet, confirm correct community's role updated (not another community's)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)