### PR TITLE
fix: stop silently dropping community-join membership rows + dedup token inserts

### DIFF
--- a/src/updaters/community.js
+++ b/src/updaters/community.js
@@ -140,59 +140,59 @@ async function updateCommunity(db, payload, blockInfo, context) {
 }
 
 async function netlink(db, payload, blockInfo, context) {
-  console.log(`Cambiatus >>> New Netlink`, blockInfo.blockNumber)
+  console.log('Cambiatus >>> New Netlink', blockInfo.blockNumber)
 
-  const countUsers = await db.users.count({ account: payload.data.new_user })
+  // NOTE: this updater runs inside the block-level serializable transaction that
+  // demux opens for every action of an on-chain tx (see handleWithState). We do NOT
+  // swallow errors here: a failed join must roll back the whole block (including the
+  // welcome issue/transfer) so we never commit a half-applied membership. All writes
+  // use ON CONFLICT DO NOTHING so a retried/re-indexed block is idempotent.
 
-  // Check if user isn't already created
-  if (countUsers === '0') {
-    try {
-      await db.users.insert({
-        account: payload.data.new_user,
-        created_block: blockInfo.blockNumber,
-        created_tx: payload.transactionId,
-        created_eos_account: payload.authorization[0].actor,
-        created_at: blockInfo.timestamp
-      })
-    } catch (e) {
-      logError('Something went wrong while inserting user', e)
-    }
-  }
+  // Idempotent user insert — relies on the unique/PK on users.account
+  await db.instance.none(
+    `INSERT INTO users (account, created_block, created_tx, created_eos_account, created_at)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT DO NOTHING`,
+    [
+      payload.data.new_user,
+      blockInfo.blockNumber,
+      payload.transactionId,
+      payload.authorization[0].actor,
+      blockInfo.timestamp
+    ]
+  )
 
-  const countNetwork = await db.network.count({
-    community_id: payload.data.community_id,
-    account_id: payload.data.new_user
+  // Idempotent membership insert — relies on the unique index on network(account_id, community_id).
+  // RETURNING yields the new row's id only when a row was actually inserted; on conflict it
+  // returns null, meaning the account is already a member and there is nothing left to do.
+  const network = await db.instance.oneOrNone(
+    `INSERT INTO network (community_id, account_id, invited_by_id, created_block, created_tx, created_eos_account, created_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     ON CONFLICT DO NOTHING
+     RETURNING id`,
+    [
+      payload.data.community_id,
+      payload.data.new_user,
+      payload.data.inviter,
+      blockInfo.blockNumber,
+      payload.transactionId,
+      payload.authorization[0].actor,
+      blockInfo.timestamp
+    ]
+  )
+
+  // Already a member — skip the role assignment
+  if (network == null) return
+
+  const role = await db.roles.findOne({ community_id: payload.data.community_id, name: 'member' })
+  if (role == null) throw new Error(`netlink: 'member' role not found for community ${payload.data.community_id}`)
+
+  await db.network_roles.insert({
+    network_id: network.id,
+    role_id: role.id,
+    inserted_at: new Date(),
+    updated_at: new Date()
   })
-
-  // if it contains at least one entry, finish the execution
-  if (countNetwork !== '0') return
-
-  // Try inserting network and roles
-  try {
-    const network = await db.network.insert({
-      community_id: payload.data.community_id,
-      account_id: payload.data.new_user,
-      invited_by_id: payload.data.inviter,
-      created_block: blockInfo.blockNumber,
-      created_tx: payload.transactionId,
-      created_eos_account: payload.authorization[0].actor,
-      created_at: blockInfo.timestamp
-    })
-
-    const role = await db.roles.findOne({ community_id: payload.data.community_id, name: 'member' })
-    if (role == null) throw new Error("Can't find role")
-
-    const networkRoleData = {
-      network_id: network.id,
-      role_id: role.id,
-      inserted_at: new Date(),
-      updated_at: new Date()
-    }
-
-    await db.network_roles.insert(networkRoleData)
-  } catch (error) {
-    logError('Something went wrong while trying to insert user and its role to the network', error)
-  }
 }
 
 function transferSale(db, payload, blockInfo, context) {

--- a/src/updaters/token.js
+++ b/src/updaters/token.js
@@ -35,32 +35,45 @@ async function updateToken (db, payload, blockInfo, context) {
     )
 }
 
-function transfer (db, payload, blockInfo, context) {
-  console.log(`Cambiatus >>> New Transfer`)
+async function transfer (db, payload, blockInfo, context) {
+  console.log('Cambiatus >>> New Transfer')
 
   const [amount, symbol] = parseToken(payload.data.quantity)
 
   const transferData = {
     from_id: payload.data.from,
     to_id: payload.data.to,
-    amount: amount,
+    amount,
     community_id: symbol,
-    memo: payload.data.memo === "" ? null : payload.data.memo,
+    memo: payload.data.memo === '' ? null : payload.data.memo,
     created_block: blockInfo.blockNumber,
     created_tx: payload.transactionId,
     created_eos_account: payload.authorization[0].actor,
     created_at: blockInfo.timestamp
   }
 
-  db.transfers
+  // Idempotency: a re-indexed block must not duplicate this row. Dedup on stable
+  // identity columns (amount is a float — excluded to avoid equality issues). This
+  // can't distinguish two truly identical transfers in one tx; the robust fix is a
+  // (created_tx, action_index) unique index added via a backend migration.
+  const existing = await db.transfers.count({
+    created_tx: payload.transactionId,
+    from_id: payload.data.from,
+    to_id: payload.data.to,
+    community_id: symbol,
+    created_block: blockInfo.blockNumber
+  })
+  if (Number(existing) > 0) return
+
+  await db.transfers
     .insert(transferData)
     .catch(e =>
       logError('Something went wrong while updating transfer data', e)
     )
 }
 
-function issue (db, payload, blockInfo, context) {
-  console.log(`Cambiatus >>> New Issue`)
+async function issue (db, payload, blockInfo, context) {
+  console.log('Cambiatus >>> New Issue')
 
   const [amount, symbol] = parseToken(payload.data.quantity)
   const data = {
@@ -74,7 +87,18 @@ function issue (db, payload, blockInfo, context) {
     created_at: blockInfo.timestamp
   }
 
-  db.mints
+  // Idempotency: a re-indexed block must not duplicate this mint. Dedup on stable
+  // identity columns (quantity is a float — excluded). See transfer() for the
+  // limitation and the proper (created_tx, action_index) backend-migration fix.
+  const existing = await db.mints.count({
+    created_tx: payload.transactionId,
+    to_id: payload.data.to,
+    community_id: symbol,
+    created_block: blockInfo.blockNumber
+  })
+  if (Number(existing) > 0) return
+
+  await db.mints
     .insert(data)
     .catch(e =>
       logError(


### PR DESCRIPTION
## Problem

A community join is one on-chain tx carrying `cambiatus.cm::netlink` + welcome `cambiatus.tk::issue` (mint) + `cambiatus.tk::transfer`. demux runs all actions of a block inside a single serializable DB transaction (`handleWithState`), so atomicity exists — but two updaters defeated it:

1. **`netlink` swallowed its own errors** (`logError` then returned normally). When the `network` insert failed, demux saw success and committed the welcome mint/transfer while the membership row was silently dropped. User ends up joined on-chain with **no `network` row** → backend `community_member?` fails; if `auto_invite=false`, sign-in is refused. Confirmed case: `maysalex1234` / `0,MUDA` (0 network rows, welcome mint+transfer present).
2. **`transfer`/`issue` had no idempotency** — bare inserts, so every reindex pass appended duplicate mint/transfer rows (maysalex: 8 mints, 4 transfers across 4 reindex passes).

## Fix

- **`netlink`** (`src/updaters/community.js`): no longer swallows errors — a failed join now propagates, rolls back the whole block, and is retried instead of committing a half-applied join. `users`/`network` inserts use `INSERT ... ON CONFLICT DO NOTHING`; `network` uses `RETURNING id` and assigns the `member` role only when a row was actually inserted (no more roleless memberships).
- **`transfer`/`issue`** (`src/updaters/token.js`): dedup guard skips the insert when an identical row (`created_tx` + from/to + community + block) already exists; insert is now awaited so it completes inside the block transaction.

## Behavior note

A *transient* netlink failure (serialization error, DB blip) self-heals on retry. A *deterministic* failure now halts the indexer loudly (rollback → retry → `unhandledRejection` → exit) instead of silently corrupting data — intentional.

## Dependencies / follow-ups (separate, not in this PR)

- Relies on existing unique index `network(account_id, community_id)` and unique `users.account`. If absent, `ON CONFLICT` degrades to plain insert (no dedup) — backend should add the index via migration.
- Robust per-tx token dedup wants a `(created_tx, action_index)` unique index (backend migration, separate deploy). Current dedup is best-effort on existing columns.
- Prod data remediation (backfill stranded joins, dedup existing duplicate rows) is operator-driven — see `HANDOFF-anomaly-remediation.md`.

No test suite exists; StandardJS lint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)