### PR TITLE
Stamp created_tx on role + network_role writes

### DIFF
--- a/src/config/local.js
+++ b/src/config/local.js
@@ -1,0 +1,31 @@
+// Local end-to-end config: syncs a local nodeos (contracts repo `make node-fresh`
+// + `make bootstrap`) into the isolated `cambiatus_local` Postgres DB.
+// Run with: NODE_ENV=local yarn start
+console.log('Loaded Local configs')
+module.exports = {
+  blockchain: {
+    contract: {
+      token: 'cambiatus.tk',
+      community: 'cambiatus.cm'
+    },
+    initialBlock: 1,
+    url: 'http://127.0.0.1:8888'
+  },
+  db: {
+    // No password key: node-pg must NOT send an empty-string password or Postgres.app
+    // rejects it under trust auth ("failed to verify trust authentication").
+    user: 'postgres',
+    host: 'localhost',
+    port: 5432,
+    database: 'cambiatus_local',
+    schema: 'public'
+  },
+  http: {
+    port: 3001
+  },
+  sentry: {
+    dsn: '',
+    environment: 'local',
+    attachStacktrace: true
+  }
+}

--- a/src/updaters/community.js
+++ b/src/updaters/community.js
@@ -55,6 +55,7 @@ async function createCommunity (db, payload, blockInfo) {
       community_id: symbol,
       name: 'member',
       permissions: '{"invite", "claim", "order", "sell", "transfer"}',
+      created_tx: payload.transactionId,
       inserted_at: new Date(),
       updated_at: new Date()
     }
@@ -76,6 +77,7 @@ async function createCommunity (db, payload, blockInfo) {
     const networkRoleData = {
       network_id: network.id,
       role_id: role.id,
+      created_tx: payload.transactionId,
       inserted_at: new Date(),
       updated_at: new Date()
     }
@@ -190,6 +192,7 @@ async function netlink (db, payload, blockInfo, context) {
   await db.network_roles.insert({
     network_id: network.id,
     role_id: role.id,
+    created_tx: payload.transactionId,
     inserted_at: new Date(),
     updated_at: new Date()
   })
@@ -514,6 +517,7 @@ async function upsertRole (db, payload, blockInfo, _context) {
     name: payload.data.name,
     color: payload.data.color,
     permissions: '{' + payload.data.permissions.map(p => `"${p}"`).join(', ') + '}',
+    created_tx: payload.transactionId,
     inserted_at: new Date(),
     updated_at: new Date()
   }
@@ -586,6 +590,7 @@ async function assignRole (db, payload, blockInfo, _context) {
     await db.network_roles.insert({
       network_id: foundNetwork.id,
       role_id: roleId,
+      created_tx: payload.transactionId,
       inserted_at: new Date(),
       updated_at: new Date()
     })


### PR DESCRIPTION
## Stamp `created_tx` on role + network_role writes

event-source already exposes the originating trx id (`action.action_trace.trx_id` → `payload.transactionId`) and writes it as `created_tx` on networks/tokens/transfers — it just omitted it on the role writes. This adds `created_tx: payload.transactionId` to all 5 role-write sites in `src/updaters/community.js` (member role on newcommunity + netlink, upsertrole, the assignroles replace-all inserts).

Enables the backend tx-tracker to confirm the **exact** transaction it broadcast for role/admin changes instead of any role change in the community (concurrent-admin safe).

**Deploy after** the backend PR (which adds the nullable `created_tx` column). Backend is back-compat: it treats a missing/NULL `created_tx` as a community-scoped fallback, so deploy order is forgiving but backend-first is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
