### PR TITLE
fix(actions): make validator sync atomic to stop dropped validators

### DIFF
--- a/src/updaters/community.js
+++ b/src/updaters/community.js
@@ -338,42 +338,36 @@ function upsertAction (db, payload, blockInfo, _context) {
     }
 
     db.withTransaction(tx => {
-      return tx.actions
-        .save(data)
-        .then(savedAction => {
-          // In case of a update delete all older validators and add new ones
-          if (payload.data.action_id > 0) {
-            db.validators
-              .destroy({ action_id: payload.data.action_id })
-              .catch(e =>
-                logError(
-                  'Something went wrong while deleting old validators',
-                  e
-                )
-              )
-          }
+      return tx.actions.save(data).then(savedAction => {
+        // On update, replace the validator set: delete the old rows then
+        // re-insert from validators_str. Both the delete and the inserts run
+        // inside `tx` and are awaited, so the transaction commits only after
+        // they complete. Previously the delete ran on `db` (a separate
+        // connection) and neither it nor the inserts were awaited, so the tx
+        // could commit before the inserts landed — or the out-of-tx delete
+        // could race and wipe them — leaving an action with zero validators
+        // and its claims permanently invisible to validators. Any failure now
+        // rolls back the whole action instead of being silently swallowed.
+        const replaceValidators =
+          payload.data.action_id > 0
+            ? tx.validators.destroy({ action_id: payload.data.action_id })
+            : Promise.resolve()
 
-          validators.map(validator => {
-            const validatorData = {
-              action_id: savedAction.id,
-              validator_id: validator,
-              created_block: blockInfo.blockNumber,
-              created_tx: payload.transactionId,
-              created_eos_account: payload.authorization[0].actor,
-              created_at: blockInfo.timestamp
-            }
-
-            tx.validators
-              .insert(validatorData)
-              .catch(e =>
-                logError(
-                  'Something went wrong while adding a validator to the list',
-                  e
-                )
-              )
-          })
-        })
-        .catch(e => logError('Error while creating an action', e))
+        return replaceValidators.then(() =>
+          Promise.all(
+            validators.map(validator =>
+              tx.validators.insert({
+                action_id: savedAction.id,
+                validator_id: validator,
+                created_block: blockInfo.blockNumber,
+                created_tx: payload.transactionId,
+                created_eos_account: payload.authorization[0].actor,
+                created_at: blockInfo.timestamp
+              })
+            )
+          )
+        )
+      })
     }).catch(e =>
       logError(
         'Something went wrong while executing transaction to create an action',


### PR DESCRIPTION
## Problem

`upsertAction` replaced an action's validators by **deleting on `db`** (a separate connection, unawaited) and **inserting on `tx`** (also unawaited). The transaction committed before the inserts completed, and the out-of-transaction delete could race and wipe the just-inserted rows. Result: actions left with **zero validators**. A `claimable` action with no validators is invisible to validators in the app, so its claims sit `pending` forever.

A manual reindex on **2026-06-13/14** replayed `cambiatus.cm::upsertaction` as updates (action_id > 0) and tripped this race at scale.

## Impact (prod, read-only audit 2026-06-29)

- **262** claimable actions reindexed 06-13/14 with 0 validators
- **187** stuck pending claims, **~80** users, across **8** communities (AGL + MUDA worst hit)
- Surfaced via a user report (validators couldn't see the claims to approve them)

## Fix

Run the delete + inserts **inside `tx`**, awaited via `Promise.all`, with the whole chain returned so the transaction commits only after they land. Drop the per-insert swallowing `.catch` so any failure rolls the action back instead of persisting a half-written action. Re-running the indexer over the affected blocks now repopulates validators reliably (also makes future reindexes safe).

## Follow-up (separate, not in this PR)

Backfill the already-broken 262 actions: re-process the affected `upsertaction` blocks with this fix deployed, then verify 0 actions with missing validators and the 187 claims become visible.

## Testing

- `npx standard` clean.
- No automated suite in this repo. Behavior validated by static analysis of the tx/promise ordering; recommend a local indexer replay of an `upsertaction` update against a dev DB before deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)