### PR TITLE
fix: resolve create-path action/objective ids from chain, not DB serial

### DIFF
--- a/src/chain.js
+++ b/src/chain.js
@@ -75,4 +75,97 @@ async function resolveClaimId (communityContract, actionId, maker, ordinal) {
   return Number(claim.id)
 }
 
-module.exports = { resolveClaimId }
+// Convert a "precision,CODE" symbol string (the format used across this repo,
+// e.g. "0,MUDA" — see eos_helper.getSymbolFromAsset) to the raw uint64 an EOS
+// node expects as a table scope, as a decimal string. Layout is the EOS symbol
+// encoding: precision in the low byte, then one code character per byte.
+// BigInt because a 7-character code occupies bits past 2^53.
+function symbolRaw (symbolString) {
+  const [precision, code] = symbolString.split(',')
+  let raw = BigInt(precision)
+  for (let i = 0; i < code.length; i++) {
+    raw |= BigInt(code.charCodeAt(i)) << BigInt(8 * (i + 1))
+  }
+  return raw.toString()
+}
+
+// Fetch every on-chain action for a single objective via the secondary index
+// on objective_id (index_position 2). An objective realistically has far fewer
+// actions than the limit; if the node still reports more, throw so we never
+// pick an id off a truncated set (fail-safe — the block retries).
+async function actionsForObjective (communityContract, objectiveId) {
+  const res = await post('/v1/chain/get_table_rows', {
+    json: true,
+    code: communityContract,
+    scope: communityContract,
+    table: 'action',
+    index_position: 2,
+    key_type: 'i64',
+    lower_bound: objectiveId,
+    upper_bound: objectiveId,
+    limit: 5000
+  })
+  if (!res || !Array.isArray(res.rows)) throw new Error(`get_table_rows(action) returned no rows for objective ${objectiveId}`)
+  if (res.more) throw new Error(`too many actions for objective ${objectiveId} to page safely`)
+  return res.rows
+}
+
+// Fetch every on-chain objective for a single community. Objectives live in a
+// per-community scope (the raw symbol value) under the primary index, so a
+// plain scan returns exactly this community's objectives. Same truncation
+// guard as above.
+async function objectivesForCommunity (communityContract, communitySymbol) {
+  const res = await post('/v1/chain/get_table_rows', {
+    json: true,
+    code: communityContract,
+    scope: symbolRaw(communitySymbol),
+    table: 'objective',
+    limit: 2000
+  })
+  if (!res || !Array.isArray(res.rows)) throw new Error(`get_table_rows(objective) returned no rows for community ${communitySymbol}`)
+  if (res.more) throw new Error(`too many objectives for community ${communitySymbol} to page safely`)
+  return res.rows
+}
+
+// Resolve the real on-chain id of the action being CREATED (upsertaction with
+// action_id = 0 — the contract generates the id and the payload doesn't carry
+// it). `knownIds` is the set of action ids already in the DB for this
+// objective. Blocks are processed in order, so the earliest chain id we don't
+// have yet is this create: the created action = the SMALLEST chain id not in
+// `knownIds`. Throws if every chain id is already known (chain/DB out of sync
+// — e.g. the create hasn't reached the node we query yet), so the block
+// retries instead of writing a wrong id.
+async function resolveCreatedActionId (communityContract, objectiveId, knownIds) {
+  const chainIds = (await actionsForObjective(communityContract, objectiveId))
+    .map(a => Number(a.id))
+    .sort((a, b) => a - b)
+
+  const created = chainIds.find(id => !knownIds.has(id))
+  if (created === undefined) {
+    throw new Error(
+      `resolveCreatedActionId: all ${chainIds.length} chain actions for objective ${objectiveId} ` +
+      'are already in the DB, nothing left to create. Retrying block.'
+    )
+  }
+  return created
+}
+
+// Same idea for objectives: the created objective = the SMALLEST chain id (in
+// this community's scope) not yet in the DB. See resolveCreatedActionId for
+// the rationale and failure semantics.
+async function resolveCreatedObjectiveId (communityContract, communitySymbol, knownIds) {
+  const chainIds = (await objectivesForCommunity(communityContract, communitySymbol))
+    .map(o => Number(o.id))
+    .sort((a, b) => a - b)
+
+  const created = chainIds.find(id => !knownIds.has(id))
+  if (created === undefined) {
+    throw new Error(
+      `resolveCreatedObjectiveId: all ${chainIds.length} chain objectives for community ${communitySymbol} ` +
+      'are already in the DB, nothing left to create. Retrying block.'
+    )
+  }
+  return created
+}
+
+module.exports = { resolveClaimId, resolveCreatedActionId, resolveCreatedObjectiveId }

--- a/src/updaters/community.js
+++ b/src/updaters/community.js
@@ -4,7 +4,7 @@ const {
   parseToken
 } = require('../eos_helper')
 const config = require(`../config/${process.env.NODE_ENV || 'dev'}`)
-const { resolveClaimId } = require('../chain')
+const { resolveClaimId, resolveCreatedActionId, resolveCreatedObjectiveId } = require('../chain')
 
 async function createCommunity (db, payload, blockInfo) {
   console.log(`Cambiatus >>> Create Community`, blockInfo.blockNumber)
@@ -279,21 +279,57 @@ async function upsertObjective (db, payload, blockInfo, _context) {
   }
 
   if (payload.data.objective_id > 0) {
+    // Update path: an idempotent upsert by id (massive's save() emits an UPDATE
+    // when the pk is present).
     data = Object.assign(data, { id: payload.data.objective_id })
-  } else {
-    // Idempotency (create path only): with no objective_id the payload carries no key, so
-    // db.objectives.save() would INSERT a fresh row on every replay, duplicating the
-    // objective. Keyed on created_tx — a create runs in exactly one on-chain tx, so a
-    // matching row means we already indexed this create. The update path (objective_id > 0)
-    // is already an idempotent upsert by id and is left untouched.
-    const existing = await db.objectives.count({ created_tx: payload.transactionId })
-    if (Number(existing) > 0) return
+    return db.objectives
+      .save(data)
+      .catch(e =>
+        logError('Something went wrong while updating objective', e)
+      )
   }
 
+  // Idempotency (create path only): with no objective_id the payload carries no key, so
+  // inserting without a guard would add a fresh row on every replay, duplicating the
+  // objective. Keyed on created_tx — a create runs in exactly one on-chain tx, so a
+  // matching row means we already indexed this create.
+  const existing = await db.objectives.count({ created_tx: payload.transactionId })
+  if (Number(existing) > 0) return
+
+  // The DB objective.id MUST equal the chain objective id — the frontend signs
+  // upsertobjctv(objective_id = db id) against the chain, so a drifted serial makes
+  // the objective un-editable (and its actions un-creatable). The create payload
+  // carries objective_id = 0 (the contract generates the id), so historically the DB
+  // serial assigned it, which drifts from the chain counter after any duplicate/extra
+  // insert. Recover the real id from chain: the smallest on-chain id this community
+  // has that we don't have yet is this create (blocks are processed in order).
+  //
+  // On any failure (chain unreachable, no missing id) we fall back to the serial
+  // rather than throw — a throw here becomes an unhandledRejection → process exit →
+  // pm2 crash-loop. The serial was realigned to the chain counter by the 2026-07-02
+  // remediation, so the fallback stays correct unless a new drift is introduced; the
+  // explicit-id path is what keeps that drift from re-opening.
+  try {
+    const known = await db.objectives.find(
+      { community_id: payload.data.community_id },
+      { fields: ['id'] }
+    )
+    data.id = await resolveCreatedObjectiveId(
+      config.blockchain.contract.community,
+      payload.data.community_id,
+      new Set(known.map(o => Number(o.id)))
+    )
+  } catch (e) {
+    logError('Could not resolve chain objective id, falling back to serial', e)
+    delete data.id
+  }
+
+  // insert(), not save(): with an id present save() emits an UPDATE (matching
+  // nothing for a new id); without one the serial assigns it.
   return db.objectives
-    .save(data)
+    .insert(data)
     .catch(e =>
-      logError('Something went wrong while updating objective', e)
+      logError('Something went wrong while creating objective', e)
     )
 }
 
@@ -347,16 +383,56 @@ function upsertAction (db, payload, blockInfo, _context) {
       })
     } else {
       // Idempotency (create path only): with no action_id the payload carries no key, so
-      // tx.actions.save() would INSERT a fresh row on every replay, duplicating the action
-      // (the audit found action ids 405+406 sharing one created_tx). Keyed on created_tx —
-      // a create runs in exactly one on-chain tx, so a matching row means we already indexed
-      // it. The update path (action_id > 0) is already an idempotent upsert by id.
+      // inserting without a guard would add a fresh row on every replay, duplicating the
+      // action (the audit found action ids 405+406 sharing one created_tx). Keyed on
+      // created_tx — a create runs in exactly one on-chain tx, so a matching row means we
+      // already indexed it. The update path (action_id > 0) is already an idempotent
+      // upsert by id.
       const existing = await db.actions.count({ created_tx: payload.transactionId })
       if (Number(existing) > 0) return
+
+      // The DB action.id MUST equal the chain action id — the frontend signs
+      // upsertaction(action_id = db id) against the chain, and claimaction carries the
+      // action_id too, so a drifted serial makes the action un-editable and its claims
+      // point at the wrong row. The create payload carries action_id = 0 (the contract
+      // generates the id), so historically the DB serial assigned it, which drifts from
+      // the chain counter after any duplicate/extra insert. Recover the real id from
+      // chain: the smallest on-chain id this objective has that we don't have yet is
+      // this create (blocks are processed in order).
+      //
+      // Resolved HERE, before db.withTransaction below — a chain HTTP round-trip inside
+      // the transaction would hold a DB connection open for its whole duration
+      // (claimAction resolves before its insert for the same reason).
+      //
+      // On any failure (chain unreachable, no missing id) we fall back to the serial
+      // rather than throw — a throw here becomes an unhandledRejection → process exit →
+      // pm2 crash-loop. The serial was realigned to the chain counter by the 2026-07-02
+      // remediation, so the fallback stays correct unless a new drift is introduced; the
+      // explicit-id path is what keeps that drift from re-opening.
+      try {
+        const known = await db.actions.find(
+          { objective_id: payload.data.objective_id },
+          { fields: ['id'] }
+        )
+        data.id = await resolveCreatedActionId(
+          config.blockchain.contract.community,
+          payload.data.objective_id,
+          new Set(known.map(a => Number(a.id)))
+        )
+      } catch (e) {
+        logError('Could not resolve chain action id, falling back to serial', e)
+        delete data.id
+      }
     }
 
     return db.withTransaction(tx => {
-      return tx.actions.save(data).then(savedAction => {
+      // Create path uses insert(), not save(): with an explicit id present save()
+      // emits an UPDATE (matching nothing for a new id); insert() honors the id, and
+      // without one the serial assigns it. The update path keeps save()'s upsert-by-id.
+      const writeAction =
+        payload.data.action_id > 0 ? tx.actions.save(data) : tx.actions.insert(data)
+
+      return writeAction.then(savedAction => {
         // On update, replace the validator set: delete the old rows then
         // re-insert from validators_str. Both the delete and the inserts run
         // inside `tx` and are awaited, so the transaction commits only after


### PR DESCRIPTION
## Problem

DB ids for actions and objectives must equal the on-chain ids: the frontend signs `upsertaction(action_id = db id)` / `upsertobjctv(objective_id = db id)`, and `claimaction` carries the action id too. The create paths let the DB serial assign the id, so any drift (historical duplicate inserts pushed the actions serial to 407 while the chain counter was at 399) makes new rows permanently un-editable — and claims signed against a drifted id can hit the wrong on-chain action.

Prod incident (2026-07-02): phantom DB actions 399–406 + objective 94 rendered as duplicate UI entries whose edits the contract rejected ("Can't find action") — the adminmuda "can't edit" report. Data remediated (phantoms deleted, serials realigned; DB=chain id-for-id at actions 1–398 / objectives 1–93). This PR keeps the drift from re-opening.

## Fix — mirror of the existing `resolveClaimId` pattern

- `chain.js`: `resolveCreatedActionId` (chain actions for the objective via the `byobj` secondary index) and `resolveCreatedObjectiveId` (per-community scope via the raw symbol value, BigInt-encoded). **Created row id = smallest on-chain id not yet in the DB for that scope** — valid because blocks are processed in order. Both throw on truncated results (`more`) or when no id is missing, so a wrong id is never written.
- `upsertObjective` / `upsertAction` create paths: after the created_tx idempotency guard, resolve the id from chain and `insert()` with it explicitly; on ANY resolution failure, log to Sentry and fall back to the (realigned) serial — a throw escaping an updater would crash-loop pm2. Resolution happens **before** `db.withTransaction` so chain HTTP never holds a DB connection.
- `insert()` not `save()` for creates: massive's `save()` with a pk present emits an UPDATE (matching nothing for a novel id — verified in massive 6.6.0 source); `claimAction` already inserts the same way.

## Notes

- Known edge (shared with resolveClaimId): a pre-existing DB gap in the same scope would mis-assign one create; DB and chain align today, so this only bites after some new unrelated discrepancy.
- StandardJS clean. No test suite in this repo; table-shape assumptions verified against `contracts/community.cpp` (`objective` per-community scope, `action` global scope + `byobj` index, both counters from `get_available_id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)