### PR TITLE
feat: persistent applied-action ledger — replay-safe reindex

### DIFF
--- a/src/GetActionsReader.js
+++ b/src/GetActionsReader.js
@@ -142,7 +142,11 @@ class GetActionsReader extends AbstractActionReader {
           payload: {
             ...act,
             transactionId: action.action_trace.trx_id,
-            actionIndex: action.account_action_seq
+            actionIndex: action.account_action_seq,
+            // Globally unique across contracts (account_action_seq is per contract and
+            // collides between cambiatus.cm and cambiatus.tk). Key of the persistent
+            // _processed_actions ledger — see updaters.js.
+            globalSequence: action.global_action_seq
           }
         })
 

--- a/src/app.js
+++ b/src/app.js
@@ -21,8 +21,21 @@ async function init () {
     `Querying EOS node on ${config.blockchain.url} via get_actions for ${contracts.join(', ')} from block#${config.blockchain.initialBlock}`
   )
 
-  massive(config.db).then(db => {
+  massive(config.db).then(async db => {
     console.info('Connected to postgres')
+
+    // Persistent ledger of applied chain actions, keyed on global_action_seq. Makes every
+    // updater replay-safe at the infrastructure level (see `ledgered` in updaters.js) —
+    // a reindex/seek over already-processed blocks becomes a no-op regardless of the
+    // per-updater guards. Indexer infra, so owned here like demux's _index_state /
+    // _block_number_txid (not a backend migration).
+    await db.instance.none(
+      `CREATE TABLE IF NOT EXISTS _processed_actions (
+         global_seq bigint PRIMARY KEY,
+         processed_at timestamptz NOT NULL DEFAULT now()
+       )`
+    )
+
     const actionHandler = new GetActionsHandler(
       updaters,
       effects,

--- a/src/updaters.js
+++ b/src/updaters.js
@@ -22,6 +22,40 @@ const {
   initacc
 } = require('./updaters/token.js')
 
+// Persistent replay guard around every updater, keyed on the action's
+// global_action_seq (set by GetActionsReader; unique across contracts). The INSERT
+// atomically claims the seq inside the same block-level transaction demux opened for the
+// updater's writes (`db` IS that transaction — see netlink/assignRole), so:
+//   * ledger row + domain writes commit or roll back together;
+//   * a reindex/seek over already-processed actions is a no-op here, regardless of the
+//     per-updater guards (which stay on as the second layer — they also cover history
+//     processed before this ledger existed, which has no rows in it);
+//   * the in-memory seenGlobalSeqs Set in the reader remains the fast path; this is the
+//     one that survives restarts.
+// Caveat (pre-existing): updaters that open their own inner db.withTransaction commit on
+// a separate connection, so their writes aren't atomic with the ledger row — exactly as
+// they already weren't atomic with demux's _block_number_txid. The per-updater guards
+// cover that window.
+function ledgered (updater) {
+  return async function (db, payload, blockInfo, context) {
+    const seq = payload.globalSequence
+    if (seq == null) return updater(db, payload, blockInfo, context)
+
+    const claimed = await db.instance.oneOrNone(
+      `INSERT INTO _processed_actions (global_seq) VALUES ($1)
+       ON CONFLICT DO NOTHING
+       RETURNING global_seq`,
+      [seq]
+    )
+    if (claimed == null) {
+      console.log(`Cambiatus >>> Skipping already-processed action (global_seq ${seq})`)
+      return
+    }
+
+    return updater(db, payload, blockInfo, context)
+  }
+}
+
 const updaters = [
   // ======== Community
   {
@@ -99,4 +133,5 @@ const updaters = [
   }
 ]
 
-module.exports = updaters
+// Every updater goes through the ledger — including ones added later.
+module.exports = updaters.map(entry => ({ ...entry, updater: ledgered(entry.updater) }))


### PR DESCRIPTION
## Problem (the structural one)

Every data incident this year — duplicate claims/orders, the notification spam, the stale claim statuses, the phantom action ids — traced back to one gap: **the indexer has no durable record of which chain actions it already applied.** The in-memory `seenGlobalSeqs` Set dies on restart/`seekToBlock`, so any reindex re-invokes every updater over existing rows, and correctness depends entirely on hand-written per-updater guards. Miss one (as happened with `reward`/`verifyClaim`) and a reindex silently corrupts prod.

## Fix

A `_processed_actions` ledger keyed on **`global_action_seq`** (globally unique; `account_action_seq` is per contract and collides between `cambiatus.cm` and `cambiatus.tk`):

- **`GetActionsReader`** forwards `global_action_seq` as `payload.globalSequence` (it already fetched it for in-memory dedup).
- **`app.js`** creates the table at boot (`CREATE TABLE IF NOT EXISTS`) — indexer infra, owned here like demux's `_index_state` / `_block_number_txid`, no backend migration needed.
- **`updaters.js`** wraps every updater (incl. future ones, via a map at export): `INSERT … ON CONFLICT DO NOTHING RETURNING` **atomically claims the seq inside the same block-level transaction** demux opened for the updater's writes — ledger row and domain writes commit or roll back together. Already-claimed seq → skip, logged.

Per-updater guards stay as the second layer: they cover history processed before the ledger existed (which has no rows), and the pre-existing window where an updater's inner `db.withTransaction` commits on a separate connection.

## Verified

- StandardJS + `node --check` clean.
- Smoke test against the dev DB: table auto-creates; first claim of a seq returns the row, replayed claim returns `null` → updater skipped.
- Deploy is just pull + restart: the table appears on first boot, no data migration.

After this merges + deploys, block-range reindexes become a sanctioned operation (runbook to follow in the workspace docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)