### PR TITLE
fix(reward): scope replay guard by created_tx — allow legit repeat awards

### DIFF
--- a/src/updaters/community.js
+++ b/src/updaters/community.js
@@ -476,13 +476,19 @@ async function reward (db, payload, blockInfo, context) {
 
   // Idempotency: a re-indexed block must not double-apply this reward. Without this guard a
   // replay both re-inserts the reward row AND decrements the action's usages_left a second
-  // time (double corruption). Keyed on (action_id, receiver_id, awarder_id) — an automatic
-  // action rewards a given receiver once per awarder, so this collapses true duplicates
-  // without dropping real rewards. Mirrors the claimAction/transfer guards.
+  // time (double corruption). Keyed on (action_id, receiver_id, awarder_id, created_tx):
+  // the contract's reward() has NO uniqueness check, so the same trio can legitimately be
+  // awarded again for a repeatable automatic action — a different tx must NOT be collapsed.
+  // Legacy rows predate the created_tx column (NULL); for those the trio alone decides,
+  // which matches the old behavior (no legitimate repeat exists in that data).
   const existing = await db.rewards.count({
     action_id: payload.data.action_id,
     receiver_id: payload.data.receiver,
-    awarder_id: payload.data.awarder
+    awarder_id: payload.data.awarder,
+    or: [
+      { created_tx: payload.transactionId },
+      { created_tx: null }
+    ]
   })
   if (Number(existing) > 0) return
 
@@ -510,11 +516,13 @@ async function reward (db, payload, blockInfo, context) {
           )
       }
 
-      // Insert reward
+      // Insert reward. created_tx is the provenance the guard above keys on — without it
+      // a legitimate repeat award is indistinguishable from a replayed block.
       const data = {
         action_id: a.id,
         receiver_id: payload.data.receiver,
         awarder_id: payload.data.awarder,
+        created_tx: payload.transactionId,
         inserted_at: new Date(),
         updated_at: new Date()
       }


### PR DESCRIPTION
**DRAFT until backend #344 is merged + deployed** — this writes the `rewards.created_tx` column that migration `20260702120000` creates. Deploying this first would fail every reward insert.

## Why

Contract audit finding: `reward()` has **no uniqueness check** — the same `(action, receiver, awarder)` can legitimately be awarded repeatedly (repeatable automatic actions with usages). The replay guard shipped in #50 keys on the trio alone, so it would silently drop a legitimate second award. Never triggered in prod data (zero repeat trios exist), but it's a correctness hole against chain semantics.

## What

- Stamp `created_tx` on reward inserts (matching every other chain-written table).
- Guard keys on `(action, receiver, awarder) AND (created_tx = this tx OR created_tx IS NULL)`:
  - exact-tx match → true replay, skip;
  - NULL match → legacy pre-column row; trio-only decides, identical to current behavior for old data;
  - same trio under a *different* tx → legitimate repeat award, inserted.
- The `_processed_actions` ledger (#52) remains the first line for anything indexed after it went live.

Verified: criteria syntax (`or` + null → `IS NULL`) exercised against the dev DB with the migrated column; StandardJS clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)